### PR TITLE
Added new snippets that align with the shell style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.2]
 
 Added a logo
+
+### [1.0.0]
+
+This release updated the format choice for function names (fn) to align with the [Shell Style Guide](https://google.github.io/styleguide/shellguide.html#function-comments)
+
+Additionally it added the following new snippets:
+- fnd : function with definitions
+- main : main
+- const : const
+- todo : TODO

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ Just a few snippets to make shellscript dev easier
 - shebang : shebang
 - e : echo
 - fn : function
+- fnd : function with definitions
 - if : if
 - ife : if else
 - elif : elif
 - until : until
+- main : main
+- const : const
+- todo : TODO
 
 ## Known Issues
 
@@ -33,5 +37,15 @@ None
 ### 0.0.2
 
 Added a logo
+
+### 1.0.0
+
+This release updated the format choice for function names (fn) to align with the [Shell Style Guide](https://google.github.io/styleguide/shellguide.html#function-comments)
+
+Additionally it added the following new snippets:
+- fnd : function with definitions
+- main : main
+- const : const
+- todo : TODO
 
 **Enjoy!**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "castello-dev",
     "repository": "https://github.com/CastelloDev/bash-snippets",
     "icon": "logo.png",
-    "version": "0.0.2",
+    "version": "1.0.0",
     "engines": {
         "vscode": "^1.65.0"
     },

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -16,11 +16,31 @@
 	"function": {
 		"prefix": "fn",
 		"body": [
-			"${1:FunctionName}() {",
+			"${1:function_name}() {",
 			"\t$0",
 			"}"
 		],
 		"description": "Function"
+	},
+	"function with definitions": {
+		"prefix": "fnd",
+		"body": [
+		  "#######################################",
+		  "# Description",
+		  "# Globals:",
+		  "# - EXPORT_1 : which contains ...",
+		  "# Arguments:",
+		  "# - \\$1 : the first paramter (eg. param1)",
+		  "# Outputs:",
+		  "# Returns:",
+		  "#######################################",
+		  "${1:lib}::${2:function_name}() {",
+		  "  local -r ${3:PARAM_1}=\"\\${1:?\"${2:function_name} is missing a parameter\"}\"",
+		  "  $0",
+		  "  export ${4:EXPORT_1}",
+		  "}"
+		],
+		"description": "Function in a libary with definitions of params and exports"
 	},
 	"if": {
 		"prefix": "if",
@@ -58,5 +78,29 @@
 			"done"
 		],
 		"description": "until block"
+	},
+	"main": {
+		"prefix": "main",
+		"body": [
+		  "main() {",
+		  "}",
+		  "",
+		  "main \"$@\""
+		],
+		"description": "a main function declaration with passthrough of all paramters passed to the file"
+	},
+	"const": {
+		"prefix": "const",
+		"body": [
+		  "local -r ${1:VARIABLE}=\"${0}\""
+		],
+		"description": "creates a local readonly variable ie. a constant (this is meant for use within functions only)"
+	},
+	"TODO": {
+		"prefix": "todo",
+		"body": [
+		  "# TODO: (${1:author}) ${0:description}"
+		],
+		"description": "creates a local readonly variable ie. a constant"
 	}
 }


### PR DESCRIPTION
This release updated the format choice for function names (fn) to align with the [Shell Style Guide](https://google.github.io/styleguide/shellguide.html#function-comments)

Additionally it added the following new snippets:
- fnd : function with definitions
- main : main
- const : const
- todo : TODO